### PR TITLE
Fix mongodb_user.py version detection logic

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -191,7 +191,7 @@ def check_compatibility(module, client):
     elif loose_srv_version >= LooseVersion('3.0') and loose_driver_version <= LooseVersion('2.8'):
         module.fail_json(msg=' (Note: you must use pymongo 2.8+ with MongoDB 3.0)')
 
-    elif loose_srv_version >= LooseVersion('2.6') and loose_srv_version <= LooseVersion('2.7'):
+    elif loose_srv_version >= LooseVersion('2.6') and loose_driver_version <= LooseVersion('2.7'):
         module.fail_json(msg=' (Note: you must use pymongo 2.7+ with MongoDB 2.6)')
 
     elif LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

database/misc/mongodb_user.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0.0 0.1.rc1
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fix mongodb_user.py version detection logic for mongo srv 2.6 and mongo driver 2.7. The wrong variable was used for detecting the mongo driver version. This fix resolves the error "(Note: you must use pymongo 2.7+ with MongoDB 2.6.. 2.6.11)" no matter what version of pymongo you had installed for mongodb 2.6.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
# Task
- name: Create mongodb users
  mongodb_user:
    login_database: admin
    login_user: "{{ mongodb_admin_user }}"
    login_password: "{{ mongodb_admin_password }}"
    login_port: "{{ mongodb_conf_port }}"
    database: "{{ item.database }}"
    name: "{{ item.user }}"
    password: "{{ item.password }}"
    ssl: "{{ mongodb_ssl }}"
    roles: "{{ item.roles|join(',') }}"
    state: present
  with_items: "{{ mongodb_db_users }}"
  tags:
    - users

# Command
[root@localhost graylog2]# ansible-playbook test/integration/default/default.yml -vvv -t users
Using /etc/ansible/ansible.cfg as config file

PLAYBOOK: default.yml **********************************************************
1 plays in test/integration/default/default.yml

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [mongodb : Create mongodb users] ******************************************
task path: /etc/ansible/roles/mongodb/tasks/main.yml:54
failed: [localhost] (item={u'password': u'backup', u'user': u'backup', u'roles': [u'backup', u'clusterMonitor'], u'database': u'admin'}) => {"failed": true, "invocation": {"module_args": {"database": "admin", "login_database": "admin", "login_host": "localhost", "login_password": "admin", "login_port": "27017", "login_user": "admin", "name": "backup", "password": "backup", "replica_set": null, "roles": ["backup", "clusterMonitor"], "ssl": false, "ssl_cert_reqs": "CERT_REQUIRED", "state": "present", "update_password": "always"}, "module_name": "mongodb_user"}, "item": {"database": "admin", "password": "backup", "roles": ["backup", "clusterMonitor"], "user": "backup"}, "msg": " (Note: you must use pymongo 2.7+ with MongoDB 2.6.. 2.6)"}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @test/integration/default/default.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```
